### PR TITLE
Changes for Datagrid module

### DIFF
--- a/src/standalone/DataGrid/Content/Cell.tsx
+++ b/src/standalone/DataGrid/Content/Cell.tsx
@@ -53,10 +53,11 @@ const Cell = (props: CellProps): React.ReactElement => {
 	}, [setState, id, prohibitMultiSelect]);
 
 	const editRecord = useCallback(() => {
-		if (id === "undefined") return;
-		if (onRowDoubleClick) onRowDoubleClick(id);
+		if (id === "undefined" || !record) return;
+		// Pass record on double click of row to supprt/choose any other field as ID
+		if (onRowDoubleClick) onRowDoubleClick(record);
 		if (onEdit) onEdit(id);
-	}, [id, onRowDoubleClick, onEdit]);
+	}, [id, onRowDoubleClick, onEdit, record]);
 
 	const column: IDataGridColumnDef | undefined =
 		columns[columnIndex - (disableSelection ? 0 : 1)];

--- a/src/standalone/DataGrid/DataGrid.tsx
+++ b/src/standalone/DataGrid/DataGrid.tsx
@@ -190,10 +190,10 @@ export interface IDataGridCallbacks {
 	onSelectionChange?: (invert: boolean, ids: string[]) => void;
 	/**
 	 * Callback for row double click
-	 * @param id The ID of the row
+	 * @param record The data of the row to choose field for double click
 	 * @remarks Called additionally before edit handler
 	 */
-	onRowDoubleClick?: (id: string) => void;
+	onRowDoubleClick?: (record: Record<string, unknown>) => void;
 	/**
 	 * Callback to check if filter is supported
 	 * @param dataType The data type


### PR DESCRIPTION
- Passed record instead of only id to allow the use of any other field as ID for onRowDoubleClick event on Datagrid